### PR TITLE
Login fix

### DIFF
--- a/packages/react-scripts/template-common/src/configuration/setup/oauth.js
+++ b/packages/react-scripts/template-common/src/configuration/setup/oauth.js
@@ -29,10 +29,11 @@ export const attemptInitialSignIn = userManager => {
             const initialRoute = routeStorage.getRoute();
 
             trace('initialRoute lookup', initialRoute);
-            if (initialRoute) {
+            if (initialRoute && isFreshRedirect) {
                 trace(`history.replace("/${initialRoute}")`);
                 history.replace(`/${initialRoute}`);
             }
+            routeStorage.discardRoute();
 
             return Promise.resolve(user);
         })


### PR DESCRIPTION
Hi. Someone pointed out a bug in the new login logic.

We always overwrote the path after a successful login with whatever was in localstorage, and we never cleared the path parameters from localstorage unless something went wrong. 

This led to strange behaviour, such as if someone tried to access a URL with query parameters, but wasn't logged in, after the redirect they would successfully be returned to the page they asked for with query parameters, as expected, but in addition, every time they accessed the page again, they would get those query parameters back. 

The fix was to only overwrite the path if we've just come from a redirect, i.e. there is an access token in the URL. Also, after every signin, we discard the saved route because we don't need it any more. 
