### PR TITLE
Improve login mechanism in rio-template-common

### DIFF
--- a/packages/rio-template-common/src/configuration/index.js
+++ b/packages/rio-template-common/src/configuration/index.js
@@ -33,11 +33,11 @@ function main(renderApp) {
     });
 
     const oauthConfig = {
-        onTokenExpired: () => {
+        onSessionExpired: () => {
             accessToken.discardAccessToken();
             store.dispatch(userSessionExpired());
         },
-        onTokenRenewed: result => {
+        onSessionRenewed: result => {
             trace('index.onTokenRenewed', result);
 
             accessToken.saveAccessToken(result.accessToken);


### PR DESCRIPTION
Until now we were marking a session as expired as soon as the access
token was expired, no matter why. With the improved login mechanism we
only mark it as expired in the case we get the error 'login_required'
when we try to do a signinSilent. In all other cases we retry the
signinSilent.

This especially improved the behavior in case the user's device was
offline for some time.