### PR TITLE
Language handling improvements

### DIFF
--- a/packages/rio-template-typescript/template/src/configuration/lang/actions.js
+++ b/packages/rio-template-typescript/template/src/configuration/lang/actions.js
@@ -5,13 +5,6 @@ export const changeLocale = locale => ({
     type: CHANGE_LOCALE,
 });
 
-export const FETCH_DISPLAY_MESSAGES = 'lang/FETCH_DISPLAY_MESSAGES';
-
-export const fetchDisplayMessages = locale => ({
-    payload: locale,
-    type: FETCH_DISPLAY_MESSAGES,
-});
-
 export const DISPLAY_MESSAGES_FETCHED = 'lang/DISPLAY_MESSAGES_FETCHED';
 
 export const displayMessagesFetched = (locale, displayMessages) => ({

--- a/packages/rio-template-typescript/template/src/configuration/lang/lang.js
+++ b/packages/rio-template-typescript/template/src/configuration/lang/lang.js
@@ -2,6 +2,7 @@ import defaultTo from 'lodash/fp/defaultTo';
 import flow from 'lodash/fp/flow';
 import head from 'lodash/fp/head';
 import split from 'lodash/fp/split';
+import has from 'lodash/fp/has';
 
 const DEFAULT_LOCALE = 'en-GB';
 
@@ -20,4 +21,7 @@ const extractLanguage = flow(
 
 const DEFAULT_LANG = extractLanguage(DEFAULT_LOCALE);
 
-export { DEFAULT_LANG, DEFAULT_LOCALE, extractLanguage, supportedLocaleMap };
+const getSupportedLocale = (preferredLocale) => has(preferredLocale, supportedLocaleMap) ?
+    supportedLocaleMap[preferredLocale] : DEFAULT_LOCALE;
+
+export { DEFAULT_LANG, DEFAULT_LOCALE, extractLanguage, supportedLocaleMap, getSupportedLocale };

--- a/packages/rio-template-typescript/template/src/configuration/lang/reducer.js
+++ b/packages/rio-template-typescript/template/src/configuration/lang/reducer.js
@@ -39,14 +39,14 @@ const isDefaultLocaleForLang = locale => supportedLocaleMap[locale] === locale;
 
 const hasLocale = locale => Boolean(supportedLocaleMap[locale]);
 
-const mergeLanguageData = (allMessages, languageData, locale) => {
+const mergeLanguageData = (allMessages, displayMessages, locale) => {
     const baseLang = extractLanguage(locale);
     const messages = {
-        [locale]: languageData,
+        [locale]: displayMessages,
     };
 
     if (isDefaultLocaleForLang(locale) || !hasLocale(baseLang)) {
-        messages[baseLang] = languageData;
+        messages[baseLang] = displayMessages;
     }
 
     return {
@@ -64,9 +64,9 @@ const langReducer = (state = defaultState, action = {}) => {
             };
         }
         case LANGUAGE_DATA_FETCHED: {
-            const { locale, languageData } = action.payload;
+            const { locale, displayMessages } = action.payload;
 
-            if (!languageData) {
+            if (!displayMessages) {
                 return {
                     ...state,
                     ...applyLocale(state, locale),
@@ -75,7 +75,7 @@ const langReducer = (state = defaultState, action = {}) => {
 
             const merged = {
                 ...state,
-                allMessages: mergeLanguageData(state.allMessages, languageData, locale),
+                allMessages: mergeLanguageData(state.allMessages, displayMessages, locale),
             };
 
             return {

--- a/packages/rio-template-typescript/template/src/configuration/lang/reducer.js
+++ b/packages/rio-template-typescript/template/src/configuration/lang/reducer.js
@@ -1,61 +1,38 @@
-import has from 'lodash/fp/has';
-
-import { CHANGE_LOCALE, LANGUAGE_DATA_FETCHED } from './actions';
-
-import { DEFAULT_LOCALE, extractLanguage, supportedLocaleMap } from './lang';
 import messagesEN from '../../features/translations/en-GB.json';
-
-const defaultMessages = {
-    en: messagesEN,
-    [DEFAULT_LOCALE]: messagesEN,
-};
-
-const getMessages = ({ allMessages }, locale) => allMessages[locale];
+import { CHANGE_LOCALE, DISPLAY_MESSAGES_FETCHED } from './actions';
+import { DEFAULT_LOCALE, getSupportedLocale } from './lang';
 
 const applyLocale = (state, preferredLocale) => {
+
     const { allMessages } = state;
-
-    const displayLocale = has(preferredLocale, allMessages) ? preferredLocale : extractLanguage(preferredLocale);
-    const supportedLocale = has(preferredLocale, supportedLocaleMap) ? preferredLocale : DEFAULT_LOCALE;
-
-    const canFetchSupportedLocale = displayLocale !== supportedLocale && supportedLocale !== DEFAULT_LOCALE;
-
-    const displayMessages = getMessages(state, supportedLocale);
+    const displayLocale = getSupportedLocale(preferredLocale);
+    const displayMessages = allMessages[displayLocale];
 
     return {
         allMessages,
-        canFetchSupportedLocale,
         displayLocale,
         displayMessages,
-        preferredLocale,
-        supportedLocale,
     };
+
 };
-
-// Initially, set DEFAULT_LOCALE and store respective displayMessages in redux store
-const defaultState = applyLocale({ allMessages: defaultMessages }, DEFAULT_LOCALE);
-
-const isDefaultLocaleForLang = locale => supportedLocaleMap[locale] === locale;
-
-const hasLocale = locale => Boolean(supportedLocaleMap[locale]);
-
-const mergeLanguageData = (allMessages, displayMessages, locale) => {
-    const baseLang = extractLanguage(locale);
-    const messages = {
-        [locale]: displayMessages,
-    };
-
-    if (isDefaultLocaleForLang(locale) || !hasLocale(baseLang)) {
-        messages[baseLang] = displayMessages;
-    }
-
+const mergeLanguageData = (allMessages, languageData, locale) => {
     return {
         ...allMessages,
-        ...messages,
+        [locale]: languageData,
     };
 };
 
-const langReducer = (state = defaultState, action = {}) => {
+const defaultMessages = {
+    [DEFAULT_LOCALE]: messagesEN,
+};
+
+export const defaultLanguageState = {
+    allMessages: defaultMessages,
+    displayMessages: null,
+    displayLocale: null,
+};
+
+const langReducer = (state = defaultLanguageState, action = {}) => {
     switch (action.type) {
         case CHANGE_LOCALE: {
             return {
@@ -63,24 +40,13 @@ const langReducer = (state = defaultState, action = {}) => {
                 ...applyLocale(state, action.payload),
             };
         }
-        case LANGUAGE_DATA_FETCHED: {
+        case DISPLAY_MESSAGES_FETCHED: {
             const { locale, displayMessages } = action.payload;
 
-            if (!displayMessages) {
-                return {
-                    ...state,
-                    ...applyLocale(state, locale),
-                };
-            }
-
-            const merged = {
-                ...state,
-                allMessages: mergeLanguageData(state.allMessages, displayMessages, locale),
-            };
-
             return {
-                ...merged,
-                ...applyLocale(merged, locale),
+                allMessages: mergeLanguageData(state.allMessages, displayMessages, locale),
+                displayMessages,
+                displayLocale: locale,
             };
         }
         default:

--- a/packages/rio-template-typescript/template/src/configuration/lang/reducer.test.js
+++ b/packages/rio-template-typescript/template/src/configuration/lang/reducer.test.js
@@ -1,20 +1,52 @@
-import get from 'lodash/fp/get';
-import omit from 'lodash/fp/omit';
+import { changeLocale, displayMessagesFetched } from './actions';
+import { DEFAULT_LOCALE } from './lang';
 
 import reducer from './reducer';
 
 describe(`features/lang/reducer`, () => {
-    it(`should provide a known default state`, () => {
-        const state = reducer();
-        expect(get('allMessages.en', state)).not.toBeUndefined();
-        expect(get('allMessages.en-GB', state)).not.toBeUndefined();
-        expect(get('displayMessages', state)).not.toBeUndefined();
+    it(`CHANGE_LOCALE should set the locale if known`, () => {
+        const germanMessages = { key: 'Message' };
+        const allMessages = { 'de-DE': germanMessages };
+        const initialState = { displayMessages: null, displayLocale: null, allMessages };
+        const expectedState = { displayMessages: germanMessages, displayLocale: 'de-DE', allMessages };
 
-        expect(omit(['allMessages', 'displayMessages'], state)).toEqual({
-            canFetchSupportedLocale: false,
-            displayLocale: 'en-GB',
-            preferredLocale: 'en-GB',
-            supportedLocale: 'en-GB',
-        });
+        const resultingState = reducer(initialState, changeLocale('de-DE'));
+        expect(resultingState).toEqual(expectedState);
+    });
+
+    it(`CHANGE_LOCALE should set the locale if supported`, () => {
+        const germanMessages = { key: 'Message' };
+        const allMessages = { 'de-DE': germanMessages };
+        const initialState = { displayMessages: null, displayLocale: null, allMessages };
+        const expectedState = { displayMessages: germanMessages, displayLocale: 'de-DE', allMessages };
+
+        const resultingState = reducer(initialState, changeLocale('de'));
+        expect(resultingState).toEqual(expectedState);
+    });
+
+    it(`CHANGE_LOCALE should set the locale to the default if unrecognized`, () => {
+        const messages = { key: 'Message' };
+        const allMessages = { [DEFAULT_LOCALE]: messages };
+        const initialState = { displayMessages: null, displayLocale: null, allMessages };
+        const expectedState = { displayMessages: messages, displayLocale: DEFAULT_LOCALE, allMessages };
+
+        const resultingState = reducer(initialState, changeLocale('invalid'));
+        expect(resultingState).toEqual(expectedState);
+    });
+
+    it(`DISPLAY_MESSAGES_FETCHED should set the locale and add the messages`, () => {
+        const messages = { key: 'Message' };
+        const allMessages = { [DEFAULT_LOCALE]: messages };
+        const initialState = { displayMessages: null, displayLocale: null, allMessages };
+
+        const newMessages = { key: 'Nachricht' };
+        const expectedState = {
+            displayMessages: newMessages,
+            displayLocale: 'de-DE',
+            allMessages: { ...allMessages, 'de-DE': newMessages },
+        };
+
+        const resultingState = reducer(initialState, displayMessagesFetched('de-DE', newMessages));
+        expect(resultingState).toEqual(expectedState);
     });
 });

--- a/packages/rio-template-typescript/template/src/configuration/lang/selectors.js
+++ b/packages/rio-template-typescript/template/src/configuration/lang/selectors.js
@@ -3,5 +3,3 @@ import get from 'lodash/fp/get';
 export const getLocale = get('lang.displayLocale');
 
 export const getDisplayMessages = get('lang.displayMessages');
-
-export const getSupportedLocale = get('lang.supportedLocale');

--- a/packages/rio-template-typescript/template/src/configuration/lang/services.js
+++ b/packages/rio-template-typescript/template/src/configuration/lang/services.js
@@ -3,7 +3,8 @@ import getOr from 'lodash/fp/getOr';
 import { reportErrorToSentry } from '../setup/sentry';
 
 import { changeLocale, displayMessagesFetched } from './actions';
-import { getSupportedLocale as defaultGetSupportedLocale } from './selectors';
+import { DEFAULT_LOCALE, getSupportedLocale as defaultGetSupportedLocale } from './lang';
+
 import { trace } from '../setup/trace';
 
 // TODO: change the module ID
@@ -38,9 +39,7 @@ export const configureFetchDisplayMessages = (
         return Promise.reject();
     }
 
-    store.dispatch(changeLocale(locale));
-    const supportedLocale = getSupportedLocale(store.getState());
-
+    const supportedLocale = getSupportedLocale(locale);
     try {
         const displayMessages = await fetchDisplayMessages(supportedLocale);
         trace(`Display messages fetched for "${supportedLocale}"`);
@@ -48,6 +47,6 @@ export const configureFetchDisplayMessages = (
     } catch (error) {
         console.error(`Display messages for "${supportedLocale}" could not be fetched.`, error);
         sendError(error);
-        return error;
+        store.dispatch(changeLocale(DEFAULT_LOCALE));
     }
 };

--- a/packages/rio-template-typescript/template/src/features/app/containers/types.ts
+++ b/packages/rio-template-typescript/template/src/features/app/containers/types.ts
@@ -1,4 +1,4 @@
-import { IdToken, LanguageDataInterface } from '../../../configuration';
+import { IdToken, DisplayMessagesInterface } from '../../../configuration';
 
 export interface AppPropertiesFromDispatch {
     hideSessionDialog: () => void;
@@ -7,7 +7,7 @@ export interface AppPropertiesFromDispatch {
 export interface AppPropertiesFromState {
     idToken: IdToken;
     homeRoute: string;
-    languageData: LanguageDataInterface;
+    displayMessages: DisplayMessagesInterface;
     showSessionExpired: boolean;
     userLocale: string;
 }


### PR DESCRIPTION
I noticed that there was a lot of old and outdated code in the language handling for the rio template. Also, there was a small error in a previously merged pull request. I decided to proactively clean up, as the old code was far more complicated than it needed to be. I've cleaned up without changing the actual business logic.

Old logic:
- Store contains multiple unused variables
- Messages were always stored twice for no reason
- Had to actually change the locale in the store to find out what the supported locale is
- Had to actually change the locale in the store to find out if the language data needs to be fetched again
- The variable denoting whether the language data needs to be refetched is never used.
- Store initially starts with english, is overwritten before render, and then overwritten again after logging in

New logic:
- Store contains only the variables needed
- Store simply starts with default messages but no selected locale
- Locale is overwritten once after login
- Simpler
- Behaviour for user remains exactly the same.