### PR TITLE
(update) use inmemory storage to store access token

### DIFF
--- a/packages/rio-template-typescript/template/src/configuration/login/login.js
+++ b/packages/rio-template-typescript/template/src/configuration/login/login.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { UserManager } from 'oidc-client';
+import { InMemoryWebStorage, UserManager, WebStorageStateStore } from 'oidc-client';
 import join from 'lodash/fp/join';
 import getOr from 'lodash/fp/getOr';
 import { mapUserProfile } from './userProfile';
@@ -42,6 +42,7 @@ export const createUserManager = () => {
         includeIdTokenInSilentRenew: false,
         automaticSilentRenew: true,
         staleStateAge: 600,
+        userStore: new WebStorageStateStore({ store: new InMemoryWebStorage() }),
     };
 
     return new UserManager(settings);


### PR DESCRIPTION
By default the oidc-client uses session storage to store the access token. This is discouraged, as it enables a gateway for xss attacks. Using the inMemory storage is a more secure solution.
