### PR TITLE
Use external whitelist text file to check valid licenses

### DIFF
--- a/packages/rio-template-typescript/template/check_licenses.sh
+++ b/packages/rio-template-typescript/template/check_licenses.sh
@@ -1,55 +1,27 @@
-#!/usr/bin/env bash
+#!/bin/bash
+
+set -eu
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 WHITELIST"
+  echo ""
+  echo "WHITELIST is a text file containing a new-line separated list of allowed licenses"
+  exit 1
+fi
+
 function join_by () { local IFS="$1"; shift; echo "$*"; }
 
 packagesToIgnore=()
 packagesToIgnore+=("rio-test-app@3.0.1")
 
-whitelistedLicenses=()
-whitelistedLicenses+=("Apache-2.0")
-whitelistedLicenses+=("Apache-1.1")
-whitelistedLicenses+=("Bouncy Castle license (MIT)")
-whitelistedLicenses+=("BSD-2-Clause")
-whitelistedLicenses+=("BSD-3-Clause")
-whitelistedLicenses+=("BSL-1.0")
-whitelistedLicenses+=("CC-BY-2.5")
-whitelistedLicenses+=("CC-BY-3.0")
-whitelistedLicenses+=("CC-BY-4.0")
-whitelistedLicenses+=("CC0-1.0")
-whitelistedLicenses+=("CDDL 1.0")
-whitelistedLicenses+=("GPL-CE + CDDL 1.1")
-whitelistedLicenses+=("Eclipse-Dist-1.0")
-whitelistedLicenses+=("Eclipse Public License v 1.0")
-whitelistedLicenses+=("Eclipse Publice License (EPL) v. 2.0")
-whitelistedLicenses+=("Fcgi")
-whitelistedLicenses+=("ICU")
-whitelistedLicenses+=("Info-ZIP")
-whitelistedLicenses+=("ISC")
-whitelistedLicenses+=("JSON.ORG")
-whitelistedLicenses+=("LGPL 2.1")
-whitelistedLicenses+=("LGPL 3.0")
-whitelistedLicenses+=("libpng")
-whitelistedLicenses+=("MIT")
-whitelistedLicenses+=("Mozilla Public license 1.1")
-whitelistedLicenses+=("Mozilla Public license 2.0")
-whitelistedLicenses+=("NTP")
-whitelistedLicenses+=("PHP-3.00")
-whitelistedLicenses+=("PHP-3.01")
-whitelistedLicenses+=("PostgreSQL")
-whitelistedLicenses+=("Public Domain")
-whitelistedLicenses+=("SAX license (=PD)")
-whitelistedLicenses+=("OSL 1.1. (The OpenSymphony Software License, Version 1.1)")
-whitelistedLicenses+=("Unlicense")
-whitelistedLicenses+=("W3C License")
-whitelistedLicenses+=("W3C-19980720")
-whitelistedLicenses+=("WTFPL")
-whitelistedLicenses+=("X11")
-whitelistedLicenses+=("zlib")
-whitelistedLicenses+=("BSD*") #mistype of "BSD-X-Clause"
-whitelistedLicenses+=("BSD") #mistype of "BSD-X-Clause"
-whitelistedLicenses+=("Apache License, Version 2.0") #mistype of "Apache-2.0"
-whitelistedLicenses+=("MPL-2.0") #Mozilla Public license 2.0 for lazy peoples. Just type the full name, would you?
+readarray -t whitelistedLicenses < "$1"
+
+if [[ ${#whitelistedLicenses[@]} -eq 0 ]]; then
+  echo "ERROR: List of allowed licenses is empty!"
+  exit 2
+fi
 
 ignoreString=$(join_by ";" "${packagesToIgnore[@]}")
 whitelistString=$(join_by ";" "${whitelistedLicenses[@]}")
 
-./node_modules/.bin/license-checker --summary --excludePackages  "${ignoreString}" --onlyAllow "${whitelistString}"
+./node_modules/.bin/license-checker --summary --excludePackages "${ignoreString}" --onlyAllow "${whitelistString}"


### PR DESCRIPTION
- remove hard-coded whitelist
- the script now requires the name of the whitelist file as argument