### PR TITLE
Sentry config should not break 'npm test'

### DIFF
--- a/packages/rio-template-typescript/template/src/configuration/setup/sentry.js
+++ b/packages/rio-template-typescript/template/src/configuration/setup/sentry.js
@@ -2,13 +2,13 @@
 import * as Sentry from '@sentry/browser';
 import { config } from '../../config';
 
-// version and environment are defined in the webpack.define plugin
-const release = SERVICE_VERSION;
-const environment = SERVICE_ENVIRONMENT;
-
-// should have been called before using it here
-// ideally before even rendering your react app
 if (config.sentryToken) {
+    // version and environment are defined in the webpack.define plugin
+    const release = SERVICE_VERSION;
+    const environment = SERVICE_ENVIRONMENT;
+
+    // should have been called before using it here
+    // ideally before even rendering your react app
     Sentry.init({
         dsn: config.sentryToken,
         environment,


### PR DESCRIPTION
Before this commit, 'npm test' raised an error because SERVICE_VERSION was undefined. 